### PR TITLE
Add file `docker/any/Dockerfile.x`

### DIFF
--- a/docker/any/Dockerfile.alpine
+++ b/docker/any/Dockerfile.alpine
@@ -1,0 +1,8 @@
+ARG NGINX_VERSION=stable
+ARG MODULE_VERSION=lts
+FROM addsp/ngx_waf-prebuild:ngx-${NGINX_VERSION}-module-${MODULE_VERSION}-musl AS Builder
+
+FROM scratch
+ARG NGINX_VERSION=stable
+ARG MODULE_VERSION=lts
+COPY --from=Builder /modules/ngx_http_waf_module.so /

--- a/docker/any/Dockerfile.debian
+++ b/docker/any/Dockerfile.debian
@@ -1,0 +1,8 @@
+ARG NGINX_VERSION=stable
+ARG MODULE_VERSION=lts
+FROM addsp/ngx_waf-prebuild:ngx-${NGINX_VERSION}-module-${MODULE_VERSION}-glibc AS Builder
+
+FROM scratch
+ARG NGINX_VERSION=stable
+ARG MODULE_VERSION=lts
+COPY --from=Builder /modules/ngx_http_waf_module.so /


### PR DESCRIPTION
Two generic Dockerfiles.

I used the [new release flow](https://add-sp.github.io/ngx_waf-docs/changes/overview.html), but the parameters `NGINX_VERSION` and `MODULE_VERSION` can still use values in numeric form, like the following.

```Dockerfile
ARG NGINX_VERSION=1.20.1
ARG MODULE_VERSION=7.1.0
```